### PR TITLE
Process multiple pages in parallel

### DIFF
--- a/check-pdf-text.py
+++ b/check-pdf-text.py
@@ -151,7 +151,9 @@ async def run_tool_async(command: str, args: list[str]):
         raise Exception(f"Command {command} failed (status {proc.returncode})")
 
 
+# nb. Might want to replace this with `tempfile` to automate temp file cleanup
 def gen_temp_filename(prefix: str, suffix="") -> str:
+    """Generate a temporary filename."""
     random_part = secrets.token_hex(8)
     return f"/tmp/{prefix}-{random_part}{suffix}"
 
@@ -290,6 +292,10 @@ class OCR:
         img = Image.open(image)
 
         out_base = gen_temp_filename("ocr-result")
+
+        # We might want to set `OMP_THREAD_LIMIT=1` here to improve throughput
+        # when Tesseract is being run for multiple pages in parallel.
+        # See https://github.com/tesseract-ocr/tesseract/blob/main/doc/tesseract.1.asc#environment-variables.
         await run_tool_async("tesseract", [image, out_base, "-l", "eng", "tsv"])
         out_path = out_base + ".tsv"
         with open(out_path) as tsv_file:

--- a/check-pdf-text.py
+++ b/check-pdf-text.py
@@ -613,7 +613,7 @@ class CSVOutputWriter(OutputWriter):
         self.csv_writer.writerow(fields)
 
 
-def windows(start, end, window_size):
+def windows(start: int, end: int, window_size: int):
     """
     Iterate over offsets for windows in the range [start, end].
 

--- a/check-pdf-text.py
+++ b/check-pdf-text.py
@@ -600,7 +600,7 @@ class CSVOutputWriter(OutputWriter):
     Writer that outputs metrics in CSV format.
     """
 
-    csv_writer: Union[csv.DictWriter, None]
+    csv_writer: Optional[csv.DictWriter]
 
     def __init__(self):
         self.csv_writer = None
@@ -633,7 +633,7 @@ def process_file(
     debug=False,
     first_page=1,
     iou_metrics=False,
-    last_page: Union[int, None] = None,
+    last_page: Optional[int] = None,
     mask_metrics=False,
     print_timings=False,
 ):

--- a/check-pdf-text.py
+++ b/check-pdf-text.py
@@ -662,7 +662,7 @@ def main():
         file_basename = os.path.basename(pdf_file)
 
         print(
-            f'Checking pages {first_page} to {last_page} in "{file_basename}" (file {file_index+1}/{file_count}',
+            f'Checking pages {first_page} to {last_page} in "{file_basename}" (file {file_index+1}/{file_count})',
             file=sys.stderr,
         )
 

--- a/check-pdf-text.py
+++ b/check-pdf-text.py
@@ -6,6 +6,7 @@ import argparse
 import asyncio
 import csv
 from dataclasses import dataclass
+from io import BytesIO, StringIO
 from math import ceil
 import os
 import random
@@ -13,7 +14,7 @@ import secrets
 import subprocess
 import sys
 import time
-from typing import cast, Protocol, Union
+from typing import cast, Optional, Protocol, Union
 import xml.etree.ElementTree as ElementTree
 
 import numpy as np
@@ -140,23 +141,22 @@ class Timer:
             print(f"  {event}: {delta}")
 
 
-async def run_tool_async(command: str, args: list[str]):
+async def run_command(
+    command: str, args: list[str], stdin: Optional[bytes] = None
+) -> bytes:
     """
-    Run a command and return the exit status.
+    Run a command and return its stdout output.
+
+    Raises if the command exits with a non-zero status.
     """
+    stdin_mode = subprocess.PIPE if stdin is not None else None
     proc = await asyncio.create_subprocess_exec(
-        command, *args, stdout=subprocess.PIPE, stderr=subprocess.PIPE
+        command, *args, stdout=subprocess.PIPE, stderr=subprocess.PIPE, stdin=stdin_mode
     )
-    await proc.communicate()
+    stdout, stderr = await proc.communicate(stdin)
     if proc.returncode != 0:
         raise Exception(f"Command {command} failed (status {proc.returncode})")
-
-
-# nb. Might want to replace this with `tempfile` to automate temp file cleanup
-def gen_temp_filename(prefix: str, suffix="") -> str:
-    """Generate a temporary filename."""
-    random_part = secrets.token_hex(8)
-    return f"/tmp/{prefix}-{random_part}{suffix}"
+    return stdout
 
 
 def iter_lines(text: str):
@@ -187,12 +187,11 @@ class PDFRenderer:
             info[field] = value
         return int(info["Pages"])
 
-    async def render_to_image(self, page: int) -> str:
+    async def render_to_image(self, page: int) -> bytes:
         """
         Render a page from a PDF to a JPEG image.
         """
-        out_base = gen_temp_filename("pdf-render-image-result")
-        await run_tool_async(
+        img_data = await run_command(
             "pdftocairo",
             [
                 "-f",
@@ -204,79 +203,76 @@ class PDFRenderer:
                 "-jpeg",
                 "-singlefile",
                 self.file_path,
-                out_base,
+                # Write to stdout
+                "-",
             ],
         )
-        return out_base + ".jpg"
+        return img_data
 
     async def render_to_text(self, page: int) -> TextPage:
         """
         Extract text with bounding boxes from a PDF page.
         """
 
-        # - Generate text file path
-        out_path = gen_temp_filename("pdf-render-text-result", suffix=".html")
-        await run_tool_async(
-            "pdftotext",
-            [
-                "-f",
-                str(page),
-                "-l",
-                str(page),
-                "-r",
-                str(self.dpi),
-                "-bbox",
-                self.file_path,
-                out_path,
-            ],
-        )
-
-        with open(out_path) as xml_file:
-            xml_content = xml_file.read()
-
-            # Strip out the XHTML namespace. This simplifies the `find` calls
-            # below.
-            xml_content = xml_content.replace(
-                'xmlns="http://www.w3.org/1999/xhtml"', ""
+        xml_content = (
+            await run_command(
+                "pdftotext",
+                [
+                    "-f",
+                    str(page),
+                    "-l",
+                    str(page),
+                    "-r",
+                    str(self.dpi),
+                    "-bbox",
+                    self.file_path,
+                    # Write to stdout
+                    "-",
+                ],
             )
+        ).decode()
 
-            # Strip out illegal characters. pdftotext doesn't escape eg.
-            # control characters appearing in words.
-            def is_legal_xml_char(char: str):
-                code = ord(char)
-                return code >= 32 or code == 0x09 or code == 0x0A or code == 0x0D
+        # Strip out the XHTML namespace. This simplifies the `find` calls
+        # below.
+        xml_content = xml_content.replace('xmlns="http://www.w3.org/1999/xhtml"', "")
 
-            xml_content = "".join([c for c in xml_content if is_legal_xml_char(c)])
+        # Strip out illegal characters. pdftotext doesn't escape eg.
+        # control characters appearing in words.
+        def is_legal_xml_char(char: str):
+            code = ord(char)
+            return code >= 32 or code == 0x09 or code == 0x0A or code == 0x0D
 
-            tree = ElementTree.fromstring(xml_content)
+        xml_content = "".join([c for c in xml_content if is_legal_xml_char(c)])
 
-            page_el = tree.find(".//page")
+        tree = ElementTree.fromstring(xml_content)
 
-            if not page_el:
-                raise Exception('"page" element not found in output')
+        page_el = tree.find(".//page")
 
-            # The `width` and `height` attributes do not change to reflect the
-            # `-r` argument to `pdftotext`, but instead always reflect the
-            # default 72 DPI, so we have to scale + ceil them.
-            dpi_scale = self.dpi / 72.0
-            width = ceil(float(page_el.attrib["width"]) * dpi_scale)
-            height = ceil(float(page_el.attrib["height"]) * dpi_scale)
+        if not page_el:
+            raise Exception('"page" element not found in output')
 
-            text_box = Rect(left=0.0, top=0.0, right=width, bottom=height)
-            text_words = []
-            word_els = page_el.findall("word")
-            for word_el in word_els:
-                text_word = TextWord(
-                    text=str(word_el.text),
-                    box=Rect(
-                        left=float(word_el.attrib["xMin"]),
-                        top=float(word_el.attrib["yMin"]),
-                        right=float(word_el.attrib["xMax"]),
-                        bottom=float(word_el.attrib["yMax"]),
-                    ),
-                )
-                text_words.append(text_word)
-            text_page = TextPage(box=text_box, words=text_words)
+        # The `width` and `height` attributes do not change to reflect the
+        # `-r` argument to `pdftotext`, but instead always reflect the
+        # default 72 DPI, so we have to scale + ceil them.
+        dpi_scale = self.dpi / 72.0
+        width = ceil(float(page_el.attrib["width"]) * dpi_scale)
+        height = ceil(float(page_el.attrib["height"]) * dpi_scale)
+
+        text_box = Rect(left=0.0, top=0.0, right=width, bottom=height)
+        text_words = []
+        word_els = page_el.findall("word")
+        for word_el in word_els:
+            text_word = TextWord(
+                text=str(word_el.text),
+                box=Rect(
+                    left=float(word_el.attrib["xMin"]),
+                    top=float(word_el.attrib["yMin"]),
+                    right=float(word_el.attrib["xMax"]),
+                    bottom=float(word_el.attrib["yMax"]),
+                ),
+            )
+            text_words.append(text_word)
+        text_page = TextPage(box=text_box, words=text_words)
 
         return text_page
 
@@ -286,20 +282,24 @@ class OCR:
     OCR uses performs Optical Character Recognition on the pixels of an image.
     """
 
-    async def run_ocr(self, image: str) -> TextPage:
+    async def run_ocr(self, image: bytes) -> TextPage:
         """
         Extract text from an image using OCR.
         """
-        img = Image.open(image)
-
-        out_base = gen_temp_filename("ocr-result")
-
         # We might want to set `OMP_THREAD_LIMIT=1` here to improve throughput
         # when Tesseract is being run for multiple pages in parallel.
         # See https://github.com/tesseract-ocr/tesseract/blob/main/doc/tesseract.1.asc#environment-variables.
-        await run_tool_async("tesseract", [image, out_base, "-l", "eng", "tsv"])
-        out_path = out_base + ".tsv"
-        with open(out_path) as tsv_file:
+        tsv_content = (
+            await run_command(
+                "tesseract", ["stdin", "stdout", "-l", "eng", "tsv"], stdin=image
+            )
+        ).decode()
+
+        with (
+            StringIO(tsv_content) as tsv_file,
+            BytesIO(image) as img_io,
+            Image.open(img_io) as img,
+        ):
             reader = csv.DictReader(
                 tsv_file,
                 delimiter="\t",
@@ -546,19 +546,19 @@ async def process_page(
     Returns a dict of comparison metrics.
     """
     t = Timer()
-    image_path = await pdf_renderer.render_to_image(page=page)
+    image_data = await pdf_renderer.render_to_image(page=page)
     t.checkpoint("render_to_image")
     pdf_text_page = await pdf_renderer.render_to_text(page=page)
     t.checkpoint("render_to_text")
 
     ocr = OCR()
-    ocr_text_page = await ocr.run_ocr(image_path)
+    ocr_text_page = await ocr.run_ocr(image_data)
     t.checkpoint("ocr")
 
     metrics: dict[str, float] = {}
 
     if debug:
-        with Image.open(image_path) as im:
+        with (BytesIO(image_data) as img_io, Image.open(image_data) as im):
             draw_boxes(im, ocr_text_page, color="rgb(0, 180, 0)", width=2)
             draw_boxes(im, pdf_text_page, color="rgb(255,0,0)", width=3)
             im.save("debug/boxes.jpg")

--- a/test-data/baselines/dna-paper.txt
+++ b/test-data/baselines/dna-paper.txt
@@ -1,2 +1,2 @@
-Page 1: iou: 0.75, iou_x: 0.97, iou_y: 0.77, iou_weighted: 0.91
-Page 2: iou: 0.75, iou_x: 0.95, iou_y: 0.78, iou_weighted: 0.90
+file: test-data/dna-paper.pdf, page: 1, iou: 0.75, iou_x: 0.97, iou_y: 0.77, iou_weighted: 0.91
+file: test-data/dna-paper.pdf, page: 2, iou: 0.75, iou_x: 0.95, iou_y: 0.78, iou_weighted: 0.90


### PR DESCRIPTION
Optimize processing of multi-page PDFs by using asyncio to execute PDF rendering and OCR in parallel for up to 10 pages at a time. On my quad-core Intel MacBook Pro this gives a speedup of ~3.7x.

In the process the usage of temporary files for outputs from `pdftotext`, `pdftocairo` and `tesseract` was eliminated. Instead data is passed in via stdin and read via stdout. Previously a fixed temp file name was used for each command and that doesn't work when the tool is being run for multiple pages concurrently.

The final commits on this branch also do some refactoring to separate the code for processing an individual file from command-line argument processing. This will make it easier to implement some lower-level tests in future.